### PR TITLE
Silence redundant-move warning

### DIFF
--- a/sources/ade/source/execution_engine.cpp
+++ b/sources/ade/source/execution_engine.cpp
@@ -138,7 +138,7 @@ std::unique_ptr<Executable> ExecutionEngine::createExecutable(const Graph& graph
         }
     }
 
-    return std::move(ret);
+    return ret;
 }
 
 void ExecutionEngine::addExecutableDependency(const std::string& lazyPassName)


### PR DESCRIPTION
Happens with gcc-9.1

```
/home/pgrunt/src/ade/sources/ade/source/execution_engine.cpp: In member function ‘std::unique_ptr<ade::Executable> ade::ExecutionEngine::createExecutable(const ade::Graph&)’:
/home/pgrunt/src/ade/sources/ade/source/execution_engine.cpp:141:21: error: redundant move in return statement [-Werror=redundant-move]
  141 |     return std::move(ret);
      |            ~~~~~~~~~^~~~~
```