### PR TITLE
replaced std::result_of with std::invoke_result

### DIFF
--- a/sources/ade/include/ade/util/func_ref.hpp
+++ b/sources/ade/include/ade/util/func_ref.hpp
@@ -43,7 +43,7 @@ public:
         m_context(reinterpret_cast<uintptr_t>(&callable)),
         m_func(&thunk<util::remove_reference_t<Callable>>)
     {
-        using actual_result_type = util::result_of_t<Callable(Args...)>;
+        using actual_result_type = util::result_of_t<Callable, Args...>;
 
         // If this condition doesn't hold, then thunk will return a reference
         // to the temporary returned by callable.

--- a/sources/ade/include/ade/util/type_traits.hpp
+++ b/sources/ade/include/ade/util/type_traits.hpp
@@ -10,6 +10,10 @@
 #define ADE_UTIL_TYPE_TRAITS_HPP
 
 #include <type_traits>
+#if defined (__has_include) && __has_include(<version>)
+    #include <version>
+#endif
+
 
 namespace ade
 {
@@ -83,9 +87,13 @@ using conditional_t = typename std::conditional<B,T,F>::type;
 template<typename... Types>
 using common_type_t = typename std::common_type<Types...>::type;
 
-template<class T>
-using result_of_t = typename std::result_of<T>::type;
-
+#ifdef __cpp_lib_is_invocable
+    template<class T, typename ...Args>
+    using result_of_t = std::invoke_result_t<T, Args...>;
+#else
+    template<class T, typename ...Args>
+    using result_of_t = typename std::result_of<T(Args...)>::type;
+#endif
 } // namespace util
 } // namespace ade
 


### PR DESCRIPTION
Fixes #22 and opencv/opencv#21109

A simple grep for `result_of` in opencv/modules does not show any further dependency of OpenCV on this trait outside of the ade library itself.