### PR TITLE
replaced std::is_pod with custom is_pod trait

### DIFF
--- a/sources/ade/include/ade/util/memory_range.hpp
+++ b/sources/ade/include/ade/util/memory_range.hpp
@@ -234,7 +234,7 @@ inline auto raw_copy(const SrcRange& src, DstRange&& dst)
 {
     static_assert(std::is_same< util::decay_t<decltype(*data(src))>,
                                 util::decay_t<decltype(*data(dst))> >::value, "Types must be same");
-    static_assert(std::is_pod< util::decay_t<decltype(*data(src))> >::value, "Types must be pod");
+    static_assert(is_pod< util::decay_t<decltype(*data(src))> >::value, "Types must be pod");
     static_assert(sizeof(src[std::size_t{}]) == sizeof(dst[std::size_t{}]), "Size mismatch");
     const auto src_size = size(src);
     const auto dst_size = size(dst);

--- a/sources/ade/include/ade/util/type_traits.hpp
+++ b/sources/ade/include/ade/util/type_traits.hpp
@@ -56,6 +56,13 @@ struct and_<T0, T...> : and_< T0, and_<T...> > {};
 template<typename T, typename ...Ts>
 struct is_one_of : or_< std::is_same<T,Ts>... > {};
 
+template <typename T>
+struct is_pod : std::integral_constant
+<
+    bool,
+    std::is_trivial<T>::value && std::is_standard_layout<T>::value
+> {};
+
 template<bool v>
 using enable_b_t = typename std::enable_if< v, bool >::type;
 


### PR DESCRIPTION
This PR replaces invocations of `std::is_pod`, which is deprecated since C++20, with a custom `is_pod` trait, which has an equivalent behavior compared with the old `std::is_pod`.  

The deprecated warning from `std::is_pod` during the build of ade was mentioned [in another comment](https://github.com/opencv/opencv/issues/21109#issuecomment-978198828) in the opencv repository.