### PR TITLE
Fixed clang -Wdeprecated-copy warnings in OpenCV

### DIFF
--- a/sources/ade/include/ade/typed_graph.hpp
+++ b/sources/ade/include/ade/typed_graph.hpp
@@ -126,6 +126,14 @@ public:
         initIds();
     }
 
+    // explicitly define copy-constructor since we modify operator=
+    ConstTypedGraph(const ConstTypedGraph<Types...>& other):
+        m_srcGraph(other.m_srcGraph)
+    {
+        details::checkUniqueNames<Types...>();
+        initIds();
+    }
+
     template<typename... OtherTypes>
     ConstTypedGraph(const ConstTypedGraph<OtherTypes...>& other):
         m_srcGraph(other.m_srcGraph)
@@ -172,6 +180,12 @@ public:
     using MetadataT  = ade::TypedMetadata<false, Types...>;
 
     TypedGraph(ade::Graph& graph):
+        ConstTypedGraph<Types...>(graph)
+    {
+    }
+
+    // explicitly define copy-constructor since we modify operator=
+    TypedGraph(TypedGraph& graph):
         ConstTypedGraph<Types...>(graph)
     {
     }


### PR DESCRIPTION
> If the class definition does not explicitly declare a copy constructor, a non-explicit one is declared [implicitly](http://eel.is/c++draft/class.copy.ctor#def:constructor,copy,implicitly_declared)[.](http://eel.is/c++draft/class.copy.ctor#6.sentence-1) If the class definition declares a move constructor or move assignment operator, the implicitly declared copy constructor is defined as deleted; otherwise, it is defaulted ([[dcl.fct.def]](http://eel.is/c++draft/dcl.fct.def))[.](http://eel.is/c++draft/class.copy.ctor#6.sentence-2) The latter case is deprecated if the class has a user-declared copy assignment operator or a user-declared destructor ([[depr.impldec]](http://eel.is/c++draft/depr.impldec))[.](http://eel.is/c++draft/class.copy.ctor#6.sentence-3)

See http://eel.is/c++draft/class.copy.ctor#6  and https://bugs.llvm.org/show_bug.cgi?id=45634

I decided to implement copy constructor instead of removing explicit `operator=` , hope it is correct.

resolves #32