### PR TITLE
Don't override CMAKE_CXX_STANDARD set by parent projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ option(FORCE_ADE_ASSERTS       "Always enable ADE_ASSERT"         OFF)
 option(BUILD_ADE_DOCUMENTATION "Build doxygen documentation"      OFF)
 option(BUILD_WITH_STATIC_CRT   "Build with static multi-threaded C Runtime (MS Windows/Visual Studio only)" OFF)
 
-set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard")
+set(CMAKE_CXX_STANDARD 11)
 
 # TODO: this is horrible hack, we must follow cmake
 # build/install policy


### PR DESCRIPTION
When ADE used as a submodule, it overrides CMAKE_CXX_STANDARD set by parent project. E.g. parent projects defines CMAKE_CXX_STANDARD as 14 and during first cmake run it's applied, but during second cmake run ADE's value is used from cache. No needs to keep CMAKE_CXX_STANDARD in cache, because it may vary from project to project.