### PR TITLE
build: remove deprecated std::iterator usage

### DIFF
--- a/sources/ade/include/ade/util/md_view.hpp
+++ b/sources/ade/include/ade/util/md_view.hpp
@@ -44,7 +44,7 @@ inline SliceDimension make_dimension(int l, int s) //TODO: move to C++14
 }
 
 template<typename ParentT, typename DiffT = int>
-class MdViewIteratorImpl final : public std::iterator<std::random_access_iterator_tag, DiffT>
+class MdViewIteratorImpl final
 {
    ParentT* m_parent = nullptr;
    int m_currentPos = -1;
@@ -70,6 +70,13 @@ class MdViewIteratorImpl final : public std::iterator<std::random_access_iterato
 
    using diff_t = DiffT;
    using val_t = decltype(ParentT()[0]);
+
+   using iterator_category = std::random_access_iterator_tag;
+   using value_type = val_t;
+   using difference_type = diff_t;
+   using pointer = val_t*;
+   using reference = val_t&;
+
 public:
 
    MdViewIteratorImpl() = default;


### PR DESCRIPTION
Fixes warnings during OpenCV build with C++17 standard (Ubuntu 24):
```
[3/2101] Building CXX object CMakeFiles/ade.dir/3rdparty/ade/ade-0.1.2d/sources/ade/source/memory_descriptor.cpp.o
In file included from /home/ubuntu/build/3rdparty/ade/ade-0.1.2d/sources/ade/include/ade/memory/memory_types.hpp:14,
                 from /home/ubuntu/build/3rdparty/ade/ade-0.1.2d/sources/ade/include/ade/memory/memory_descriptor.hpp:14,
                 from /home/ubuntu/build/3rdparty/ade/ade-0.1.2d/sources/ade/source/memory_descriptor.cpp:7:
/home/ubuntu/build/3rdparty/ade/ade-0.1.2d/sources/ade/include/ade/util/md_view.hpp:47:46: warning: 'template<class _Category, class _Tp, class _Distance, class _Pointer, class _Reference> struct std::iterator' is deprecated [-Wdeprecated-declarations]
   47 | class MdViewIteratorImpl final : public std::iterator<std::random_access_iterator_tag, DiffT>
      |                                              ^~~~~~~~
```

**Note**: perhaps there was a mistake - `DiffT` was used as a second template argument, meaning that it will be declared `value_type`. While in other places in this class different declarations `val_t` and `diff_t` exist, so I used them instead.
```
template<
    class Category,
    class T,
    class Distance = std::ptrdiff_t,
    class Pointer = T*,
    class Reference = T&
> struct iterator;
```